### PR TITLE
Udskifter svenske logoer med KU-logo i frontenden.

### DIFF
--- a/korp/frontend/Dockerfile
+++ b/korp/frontend/Dockerfile
@@ -47,8 +47,11 @@ WORKDIR /opt/korp-frontend
 RUN yarn
 
 # Recursively patch korp-frontend source code - provides basic UI localisation
-COPY app/* /opt/korp-frontend/frontend-base-patch/
-RUN cp -r /opt/korp-frontend/frontend-base-patch/* /opt/korp-frontend/app/
+# Copy files in local "app" to corresponding paths in "/opt/korp-frontend/app",
+# without substituting existing dirs. (config.js will be replaced, files in
+# includes and translations dirs will be replaced if files with corresponding file names are present
+# in local app/includes and app/translations -- the full dirs are NOT replaced).
+COPY app /opt/korp-frontend/app
 
 # Include a script to sync mode and translation files from config/ to dist/.
 # Run `docker-compose exec frontend sync.sh` in same dir as docker-compose.yml.

--- a/korp/frontend/app/includes/header.pug
+++ b/korp/frontend/app/includes/header.pug
@@ -75,8 +75,7 @@
       div
         p(style='padding: 10px; margin: 0px;')
     span.logos.d-none.d-xl-block
-      a(href="https://spraakbanken.gu.se" target="_blank")
-        img(src="img/sbx1r.svg" style='position: relative; top: 15px;')
-      a(href="https://sweclarin.se" target="_blank")
-        img(src="img/sweclarin_logo.png")
+      a(href="https://nors.ku.dk" target="_blank" style="color: black;")
+        span Institut for Nordiske Studier og Sprogvidenskab
+        img(src="https://cms.ku.dk/bootstrap/images/branding/faelles.svg" style='position: relative; top: 3px;')
   select#search_history.d-lg-block.d-none


### PR DESCRIPTION
Bemærk: Nu med korrekt COPY-kommando i frontenden.